### PR TITLE
Allow usage in Electron renderer

### DIFF
--- a/src/BatchCluster.ts
+++ b/src/BatchCluster.ts
@@ -8,6 +8,7 @@ import { Rate } from "./Rate"
 import { Task } from "./Task"
 import { ChildProcess } from "child_process"
 import * as _p from "process"
+import * as _timers from "timers"
 
 /**
  * These are required parameters for a given BatchCluster.
@@ -259,7 +260,7 @@ export class BatchCluster {
   ) {
     this.opts = verifyOptions(opts)
     if (this.opts.onIdleIntervalMillis > 0) {
-      this.onIdleInterval = setInterval(
+      this.onIdleInterval = _timers.setInterval(
         () => this.onIdle(),
         this.opts.onIdleIntervalMillis
       )


### PR DESCRIPTION
In the Electron renderer `setInterval` is the browser `window.setInterval` and `batch-cluster` fails as its expecting `setInterval` to return a `NodeJS.Timer`.

This should allow `exiftool-vendored` to work in the Electron renderer.

See this users stackoverflow question:
https://stackoverflow.com/questions/48961238/electron-setinterval-implementation-difference-between-chrome-and-node